### PR TITLE
Prioritise JWT_SECRET regardless of NODE_ENV

### DIFF
--- a/api/services/auth.service.js
+++ b/api/services/auth.service.js
@@ -1,6 +1,6 @@
 const jwt = require('jsonwebtoken');
 
-const secret = process.env.NODE_ENV === 'production' ? process.env.JWT_SECRET : 'secret';
+const secret = process.env.JWT_SECRET || process.env.NODE_ENV === 'production' ? process.env.JWT_SECRET : 'secret';
 
 module.exports = {
   issue: (payload) => jwt.sign(payload, secret, { expiresIn: 10800 }),


### PR DESCRIPTION
This simple change prioritise JWT_SECRET other 'secret' in all environments.